### PR TITLE
Fix relative date labels for afternoon/evening events

### DIFF
--- a/lib/rdt.rb
+++ b/lib/rdt.rb
@@ -66,7 +66,7 @@ module ICalPal
       return strftime($opts[:df]) if $opts && $opts[:df] && $opts[:nrd]
       return super unless $today && $opts
 
-      case (self - $today).round
+      case (self - $today).floor
       when -2 then 'day before yesterday'
       when -1 then 'yesterday'
       when 0 then 'today'


### PR DESCRIPTION
## Summary
  - Fix `RDT#to_s` to use `floor` instead of `round` when calculating relative date labels

## Problem
Events after noon were incorrectly labeled as "tomorrow" instead of "today" for users in UTC+ timezones.

When comparing an event at 13:00 to `$today` (midnight 00:00), the difference is 13/24 = 0.54 days:
  - `round(0.54)` = 1 → "tomorrow" (wrong)
  - `floor(0.54)` = 0 → "today" (correct)