### PR TITLE
fix: Add missing runtime dependencies to gemspec

### DIFF
--- a/icalPal.gemspec
+++ b/icalPal.gemspec
@@ -30,6 +30,10 @@ EOF
 
   s.bindir = 'bin'
   s.required_ruby_version = '>= 2.6.0'
+  s.add_runtime_dependency 'logger'
+  s.add_runtime_dependency 'csv'
+  s.add_runtime_dependency 'rdoc'
+  s.add_runtime_dependency 'sqlite3'
 
   s.post_install_message = <<-EOF
 


### PR DESCRIPTION
## Problem
icalPal fails when installed via Homebrew with errors like:
- `cannot load such file -- logger`
- `cannot load such file -- csv`
- `cannot load such file -- rdoc`
- `cannot load such file -- sqlite3`

Environment: MacOS 15.7.2 (24G325)

## Root Cause
The gemspec doesn't declare runtime dependencies. When Homebrew installs 
icalPal with an isolated GEM_PATH, these gems aren't available.
## Solution
Add explicit runtime dependencies for:
- `logger` - logging functionality
- `csv` - CSV output format
- `rdoc` - RDoc/Markdown/HTML output formats
- `sqlite3` - Calendar database access
These were previously implicit dependencies that worked when using system 
Ruby's default gem paths, but fail in isolated environments like Homebrew.

This is tested locally and works.

Note I am not a Ruby expert so not 100% sure this is the right approach but it seems accurate.
