### PR TITLE
Skip nil input and memoize plconvert

### DIFF
--- a/lib/utils.rb
+++ b/lib/utils.rb
@@ -1,10 +1,24 @@
 PL_CONVERT = '/usr/bin/plutil -convert xml1 -o - -'.freeze
 
+# Memoize plist conversions so duplicate inputs don't fork plutil
+# repeatedly. ICalPal::Reminder#initialize calls `plconvert` per row
+# for `color` (one of ~12 unique blobs across the user's lists,
+# duplicated across thousands of reminders by the SQL JOIN) and
+# `messaging` (almost always nil for typical data). Sharing results
+# across calls turns N plutil forks into one per unique input.
+PLCONVERT_CACHE = {}
+
 # Load a plist
 #
 # @param obj [String] Data that can be converted by +/usr/bin/plutil+
-# @return [Array] Objects representing nodes in the plist
+# @return [Array] Objects representing nodes in the plist; +nil+ for
+#   nil/empty input.
 def plconvert(obj)
+  return nil if obj.nil? || (obj.respond_to?(:empty?) && obj.empty?)
+
+  cached = PLCONVERT_CACHE[obj]
+  return cached if cached || PLCONVERT_CACHE.key?(obj)
+
   r 'open3'
   r 'plist'
 
@@ -16,12 +30,14 @@ def plconvert(obj)
   sin.close
 
   # Read output
-  begin
-    plist = Plist.parse_xml(sout.read)
-    plist['$objects'] if plist
-  rescue Plist::UnimplementedElementError
-    nil
-  end
+  result = begin
+             plist = Plist.parse_xml(sout.read)
+             plist['$objects'] if plist
+           rescue Plist::UnimplementedElementError
+             nil
+           end
+
+  PLCONVERT_CACHE[obj] = result
 end
 
 # Convert a key/value pair to XML.  The value should be +nil+, +String+,

--- a/test/plconvert_test.rb
+++ b/test/plconvert_test.rb
@@ -1,0 +1,107 @@
+# Tests for plconvert in lib/utils.rb.
+#
+# Run via:
+#   ruby test/plconvert_test.rb
+
+require 'minitest/autorun'
+require 'open3'
+require 'stringio'
+
+# icalPal's lib uses `rr` and `r` helpers defined in bin/icalPal,
+# so requiring the lib directly fails. Define them here, then load.
+def r(gem)
+  require gem
+end
+
+def rr(library)
+  require_relative File.join(__dir__, '..', 'lib', library.to_s)
+end
+
+%w[ logger csv json rdoc sqlite3 yaml ].each { |g| r(g) }
+%w[ icalPal defaults options utils ].each { |l| rr(l) }
+
+class PlconvertTest < Minitest::Test
+  # Replace Open3.popen3 with a recording stub for the duration of the
+  # block. Each call appends its argument list to +log+ and returns a
+  # tuple shaped like the real popen3 result. Avoids depending on
+  # Minitest::Mock (removed in minitest 6.x).
+  def with_popen3_stub
+    log = []
+    Open3.singleton_class.send(:alias_method, :_orig_popen3, :popen3)
+    Open3.define_singleton_method(:popen3) do |*args|
+      log << args
+      [
+        StringIO.new(+'', 'w'),
+        StringIO.new('<?xml version="1.0"?><plist></plist>'),
+        StringIO.new,
+        Object.new
+      ]
+    end
+    yield log
+  ensure
+    Open3.singleton_class.send(:alias_method, :popen3, :_orig_popen3)
+    Open3.singleton_class.send(:remove_method, :_orig_popen3)
+  end
+
+  def setup
+    PLCONVERT_CACHE.clear
+  end
+
+  def test_returns_nil_for_nil_input_without_spawning_a_subprocess
+    with_popen3_stub do |log|
+      assert_nil plconvert(nil)
+      assert_empty log,
+                   'plconvert(nil) must not fork plutil'
+    end
+  end
+
+  def test_returns_nil_for_empty_string_without_spawning_a_subprocess
+    with_popen3_stub do |log|
+      assert_nil plconvert('')
+      assert_empty log,
+                   'plconvert("") must not fork plutil'
+    end
+  end
+
+  def test_memoizes_by_input_bytes
+    with_popen3_stub do |log|
+      plconvert('the-same-blob')
+      plconvert('the-same-blob')
+      plconvert('the-same-blob')
+      assert_equal 1, log.size,
+                   'plconvert should only fork plutil once per unique input'
+    end
+  end
+
+  def test_distinct_blobs_each_spawn_their_own_subprocess
+    with_popen3_stub do |log|
+      plconvert('blob-A')
+      plconvert('blob-B')
+      assert_equal 2, log.size
+    end
+  end
+
+  def test_caches_nil_results_so_a_failing_blob_is_not_retried
+    Open3.singleton_class.send(:alias_method, :_orig_popen3, :popen3)
+    log = []
+    Open3.define_singleton_method(:popen3) do |*args|
+      log << args
+      [
+        StringIO.new(+'', 'w'),
+        StringIO.new('not-a-plist'),
+        StringIO.new,
+        Object.new
+      ]
+    end
+
+    begin
+      assert_nil plconvert('bad-blob')
+      assert_nil plconvert('bad-blob')
+      assert_equal 1, log.size,
+                   'a blob that produced nil should still be cached'
+    ensure
+      Open3.singleton_class.send(:alias_method, :popen3, :_orig_popen3)
+      Open3.singleton_class.send(:remove_method, :_orig_popen3)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

`plconvert` (in `lib/utils.rb`) is called twice per reminder by `Reminder#initialize` — once for `color`, once for `messaging`. Each call forks `/usr/bin/plutil`. On a typical 4000-reminder store that's ~8000 fork+exec invocations, which dominates cold-start runtime for the `tasks` command.

Two observations on real data make the work redundant:

- **`messaging` (`zContactHandles`) is null for the vast majority of reminders.** Every `plconvert(nil)` call still forks plutil, sends an empty stdin, and comes back with nothing.
- **`color` is a list-level attribute** that the SQL JOIN duplicates onto every reminder row. ~12 unique color blobs across ~40 lists end up getting re-parsed thousands of times.

Empirical impact (3853-reminder store):

- 100 sequential `plutil` invocations: ~0.43 s.
- 7700 sequential invocations (the worst case here): ~33 s.
- After this fix, ~12 invocations: ~0.05 s.

This is one of two upstream fixes that take this user's `icalpal tasks` cold start from ~100 s to ~0.6 s. The other is filed separately as an issue (the `ZMembershipsOfRemindersInSectionsAsData` blob join in `Reminder::QUERY` — happy to file that as a PR too once we agree on the right SQL approach).

## The fix

Two changes in `lib/utils.rb`:

```ruby
def plconvert(obj)
  return nil if obj.nil? || (obj.respond_to?(:empty?) && obj.empty?)

  cached = PLCONVERT_CACHE[obj]
  return cached if cached || PLCONVERT_CACHE.key?(obj)

  # ... existing fork+parse logic ...

  PLCONVERT_CACHE[obj] = result
end
```

Plus a top-level `PLCONVERT_CACHE = {}` constant for the cache itself.

The `cached || PLCONVERT_CACHE.key?(obj)` check makes nil results cacheable too — a blob that fails to parse (`Plist::UnimplementedElementError` returns nil) doesn't get re-tried per row.

## Behavior preservation

- Parsed objects for the same input are byte-identical to the previous behavior (we cache plutil's own output).
- nil inputs previously went through plutil → the rescue-or-empty-result path → effectively nil. The shim returns nil directly, same observable result.
- No public API changes. Return shape (Array of plist objects, or nil) is unchanged.
- Process-scoped cache; not thread-safe (icalPal is single-threaded).

## Tests

Adds `test/plconvert_test.rb` — 5 cases using stdlib minitest:

- nil input returns nil without spawning a subprocess
- empty string returns nil without spawning a subprocess
- repeated calls with the same input only fork plutil once
- distinct inputs each spawn their own subprocess
- a blob that produces nil is still cached (no re-fork on subsequent calls)

The Open3 stub is implemented via singleton-method aliasing rather than `Minitest::Mock` because the latter was removed in minitest 6.x — the test file should run cleanly on either minitest version.

Run with:

```sh
ruby test/plconvert_test.rb
```

I confirmed the suite catches the regression — reverting the patch causes all 5 tests to fail.

## Notes

- No changes to runtime dependencies, gemspec, or executable surface.
- Rubocop clean against the project's existing style.
- Happy to adjust naming (`PLCONVERT_CACHE` could be private inside a module if you'd prefer), wrap the cache in something LRU-bounded, or split the changes if you want them in smaller pieces.