### PR TITLE
Skip nil-anchor events in non_recurring instead of crashing

### DIFF
--- a/lib/event.rb
+++ b/lib/event.rb
@@ -117,6 +117,16 @@ module ICalPal
     def non_recurring
       events = []
 
+      # Real Calendar.app data sometimes has events whose sdate / edate /
+      # duration is nil (malformed subscribed calendars, partial syncs,
+      # post-migration rows). Skip the row entirely if there's no anchor
+      # date; otherwise coerce the missing optional fields so the math
+      # below doesn't blow up.
+      return events if self['sdate'].nil?
+
+      self['duration'] ||= 0
+      self['edate']    ||= self['sdate']
+
       nDays = (self['duration'] / 86_400).to_i
 
       # Sanity checks

--- a/test/event_nil_safe_test.rb
+++ b/test/event_nil_safe_test.rb
@@ -1,0 +1,102 @@
+# Regression test for Event#non_recurring when icalpal encounters
+# events whose sdate / edate / duration is nil. Real Calendar.app data
+# contains rows where these fields are missing (e.g. malformed
+# subscribed calendars, partial syncs from CalDAV servers, or events
+# that lost their date during a Sequoia migration).
+#
+# Prior to the fix, icalpal aborted the entire output with one of:
+#
+#   NoMethodError: undefined method '/' for nil:NilClass
+#       (lib/event.rb:120 — `(self['duration'] / 86_400).to_i`)
+#
+#   ArgumentError: comparison of NilClass with ICalPal::RDT failed
+#       (lib/event.rb:321 — `[ s, e ].max >= $opts[:from]` with nil e)
+#
+#   NoMethodError: undefined method 'to_a' for nil:NilClass
+#       (lib/event.rb:126 — `@self['sdate'].to_a` with nil sdate)
+#
+# Run via:
+#   ruby test/event_nil_safe_test.rb
+
+require 'minitest/autorun'
+
+# icalPal's lib uses `rr` and `r` helpers defined in bin/icalPal,
+# so requiring the lib directly fails. Define them here, then load.
+def r(gem)
+  require gem
+end
+
+def rr(library)
+  require_relative File.join(__dir__, '..', 'lib', library.to_s)
+end
+
+%w[ logger csv json rdoc sqlite3 yaml ].each { |g| r(g) }
+%w[ icalPal defaults options utils ].each { |l| rr(l) }
+
+class EventNilSafeTest < Minitest::Test
+  # Build an Event-like object whose @self is the passed hash, bypassing
+  # the heavy ICalPal::Event#initialize (JSON.parse on attendees, date
+  # conversions, etc.) so the test focuses purely on non_recurring's
+  # nil handling.
+  class TestEvent < ICalPal::Event
+    def initialize(self_hash)
+      @self = self_hash
+    end
+  end
+
+  def setup
+    # ICalPal::Event#non_recurring reads $opts[:to] / $opts[:from] /
+    # $opts[:now] inside the loop and the in_window? helper. Set bounds
+    # that include any sdate we might construct, but ensure the loop
+    # terminates after a single iteration (duration=0 → nDays=0).
+    far_past   = ICalPal::RDT.new(2000, 1, 1, 0, 0, 0, '+00:00')
+    far_future = ICalPal::RDT.new(2100, 1, 1, 0, 0, 0, '+00:00')
+    $opts = { from: far_past, to: far_future, now: false, sep: 'date' }
+    $log = Logger.new(IO::NULL)
+  end
+
+  def test_nil_sdate_returns_empty_array_instead_of_crashing
+    event = TestEvent.new('sdate' => nil, 'edate' => nil, 'duration' => nil, 'title' => 'Bad row')
+
+    # Regression: without the fix, this raised NoMethodError on '/' for nil.
+    assert_equal [], event.non_recurring,
+                 'nil sdate should cause non_recurring to skip the row, not crash'
+  end
+
+  def test_nil_duration_is_coerced_to_zero
+    sdate = ICalPal::RDT.new(2026, 4, 24, 9, 0, 0, '+00:00')
+    edate = ICalPal::RDT.new(2026, 4, 24, 10, 0, 0, '+00:00')
+    event = TestEvent.new('sdate' => sdate, 'edate' => edate, 'duration' => nil, 'title' => 'No duration')
+
+    refute_nil event.non_recurring,
+               'nil duration should be coerced to 0 so non_recurring runs'
+    assert_equal 0, event['duration'],
+                 'duration should have been set to 0'
+  end
+
+  def test_nil_edate_is_coerced_to_sdate
+    sdate = ICalPal::RDT.new(2026, 4, 24, 9, 0, 0, '+00:00')
+    event = TestEvent.new('sdate' => sdate, 'edate' => nil, 'duration' => 0, 'title' => 'No edate')
+
+    # Regression: without the fix, in_window?'s `[s, e].max` raised
+    # ArgumentError on the nil edate.
+    refute_nil event.non_recurring
+    refute_nil event['edate'],
+               'edate should have been coerced to sdate'
+  end
+
+  def test_normal_event_path_is_unaffected
+    sdate = ICalPal::RDT.new(2026, 4, 24, 9, 0, 0, '+00:00')
+    edate = ICalPal::RDT.new(2026, 4, 24, 10, 0, 0, '+00:00')
+    event = TestEvent.new(
+      'sdate'    => sdate,
+      'edate'    => edate,
+      'duration' => 3600,
+      'title'    => 'Normal event'
+    )
+
+    result = event.non_recurring
+    refute_empty result,
+                 'a well-formed in-window event should still be returned'
+  end
+end


### PR DESCRIPTION
## Summary

`Event#non_recurring` does arithmetic on `self['duration']`, `self['sdate']`, and `self['edate']` without nil checks. Real Calendar.app data occasionally contains rows where these fields are missing — likely malformed subscribed calendars, partial syncs from CalDAV servers, or post-Sequoia migration rows.

When that happens, icalpal aborts the **entire output** with one of:

```
NoMethodError: undefined method '/' for nil:NilClass
    (lib/event.rb:120 — `(self['duration'] / 86_400).to_i`)

ArgumentError: comparison of NilClass with ICalPal::RDT failed
    (lib/event.rb:321 — `[ s, e ].max >= $opts[:from]` with nil e)

NoMethodError: undefined method 'to_a' for nil:NilClass
    (lib/event.rb:126 — `@self['sdate'].to_a` with nil sdate)
```

In my case a single malformed row in a subscribed calendar takes the whole `events` / `eventsToday` / `week` output to zero events. I've been working around it locally with a `Module#prepend` patch in a downstream tool ([`calq`](https://github.com/tilthouse/calq)/[`remq`](https://github.com/tilthouse/remq)), but it really belongs upstream.

## The fix

Three lines at the top of `non_recurring`:

```ruby
return events if self['sdate'].nil?

self['duration'] ||= 0
self['edate']    ||= self['sdate']
```

- nil sdate is unrecoverable (no anchor) → skip the row, return `[]`.
- nil duration is treated as a zero-length event → `nDays = 0`, runs once.
- nil edate falls back to sdate → `in_window?`'s `[s, e].max` no longer raises.

Order matters: the sdate guard must come first so the subsequent `||= self['sdate']` is safe.

## Tests

Adds `test/event_nil_safe_test.rb` — 4 cases using stdlib minitest:

- nil sdate returns `[]` without raising `NoMethodError`
- nil duration is coerced to 0
- nil edate is coerced to sdate (avoids the in_window? `ArgumentError`)
- well-formed in-window event is still returned (sanity)

The test class subclasses `ICalPal::Event` and overrides `initialize` to bypass the JSON.parse / date-conversion machinery, isolating the test surface to `non_recurring` itself.

Run with:

```sh
ruby test/event_nil_safe_test.rb
```

I confirmed the suite catches the regressions — reverting the patch produces three errors with the exact line numbers cited in the documentation comment.

## Notes

- No changes to runtime dependencies, gemspec, or executable surface.
- The `Reminder` path doesn't reach `non_recurring` (icalpal's `bin/icalPal` only calls it on Events), so no test there.
- Filing context: this is the third of three patches I had stacked locally. The other two are #53 (RestoreIdField, merged in 4.2.0) and #55 (plconvert nil-skip + memoize, currently open). Combined with this one, my downstream tool's `lib/.../icalpal_patch.rb` becomes empty and the icalPal version pin can be bumped.